### PR TITLE
[echelon] add plugins that echelon depends on

### DIFF
--- a/recipes/carbon.rb
+++ b/recipes/carbon.rb
@@ -1,0 +1,28 @@
+#
+# Cookbook Name:: collectd_plugins
+# Recipe:: graphite
+#
+# Copyright 2012, AJ Christensen <aj@junglist.gen.nz>
+#
+
+case node.platform
+when "ubuntu", "debian"
+  package "libpython2.7"
+end
+
+remote_file File.join(node[:collectd][:plugin_dir], "carbon_writer.py") do
+  source "https://raw.github.com/indygreg/collectd-carbon/master/carbon_writer.py"
+  owner "root"
+  group "root"
+  mode "644"
+  action :create_if_missing
+end
+
+collectd_python_plugin "carbon_writer" do
+  options(:line_receiver_host => "127.0.0.1",
+          :line_receiver_port => 2003,
+          :differentiate_counters_over_time => true,
+          :lowercase_metric_names => true,
+          "TypesDB" => node[:collectd][:types_db],
+          :metric_prefix => "collectd" )
+end

--- a/recipes/chef.rb
+++ b/recipes/chef.rb
@@ -1,0 +1,52 @@
+#
+# Cookbook Name:: collectd_plugins
+# Recipe:: chef
+#
+# Copyright 2010, Atari
+#
+# All rights reserved - Do Not Redistribute
+#
+
+include_recipe "collectd"
+
+class ChefCollectdPluginReportHandler < Chef::Handler
+  def report
+    Chef::Log.info('Running collectd hander')
+    node[:last_success_time] = Time.now.to_f
+    node[:error_count_since_success] = 0
+    node.save
+  end
+end
+
+class ChefCollectdPluginErrorHandler < Chef::Handler
+  def report
+    node[:last_error_time] = Time.now.to_f
+    if not node.include? :error_count
+      node[:error_count] = 0
+    end
+    node[:error_count] += 1
+    if not node.include? :error_count_since_success
+      node[:error_count_since_success] = 0
+    end
+    node[:error_count_since_success] += 1
+    node.save
+  end
+end
+
+# Remove any previous instances so we don't end up with more than one
+# This cannot use is_a? since the class gets recompiled on each run
+Chef::Config.report_handlers.delete_if {|v| v.class.to_s.include? 'ChefCollectdPluginReportHandler'}
+Chef::Config.report_handlers << ChefCollectdPluginReportHandler.new
+
+Chef::Config.exception_handlers.delete_if {|v| v.class.to_s.include? 'ChefCollectdPluginErrorHandler'}
+Chef::Config.exception_handlers << ChefCollectdPluginErrorHandler.new
+
+cookbook_file File.join(node[:collectd][:plugin_dir], "chef.py") do
+  owner "root"
+  group "root"
+  mode "644"
+end
+
+collectd_python_plugin "chef" do
+  options :verbose=>true
+end

--- a/recipes/graphite.rb
+++ b/recipes/graphite.rb
@@ -1,0 +1,28 @@
+#
+# Cookbook Name:: collectd_plugins
+# Recipe:: graphite
+#
+# Copyright 2012, AJ Christensen <aj@junglist.gen.nz>
+#
+
+case node.platform
+when "ubuntu", "debian"
+  package "nodejs"
+end
+
+script_path = File.join(node[:collectd][:plugin_dir], "collectd-graphite-proxy.js")
+
+remote_file script_path do
+  source "https://raw.github.com/loggly/collectd-to-graphite/master/collectd-graphite-proxy.js"
+  owner "root"
+  group "root"
+  mode "644"
+end
+
+runit_service "collectd-graphite-proxy" do
+  options :script_path => script_path
+end
+
+collectd_plugin "write_http" do
+  options "URL" => "http://127.0.0.1:3012/post-collectd"
+end

--- a/recipes/librato.rb
+++ b/recipes/librato.rb
@@ -1,0 +1,24 @@
+#
+# Cookbook Name:: collectd_plugins
+# Recipe:: librato
+#
+# Copyright 2012, Sean Escriva <sean.escriva@gmail.com>
+#
+
+case node.platform
+when "ubuntu", "debian"
+  package "libpython2.7"
+end
+
+cookbook_file File.join(node[:collectd][:plugin_dir], "collectd-librato.py") do
+  owner "root"
+  group "root"
+  mode "644"
+end
+
+librato_creds = data_bag_item("librato", node.chef_environment)
+
+collectd_python_plugin "collectd-librato" do
+  options( :email => librato_creds["email"],
+           "APIToken" => librato_creds["api_key"] )
+end

--- a/recipes/load.rb
+++ b/recipes/load.rb
@@ -1,0 +1,9 @@
+#
+# Cookbook Name:: collectd_plugins
+# Recipe:: load
+#
+# Copyright 2012, AJ Christensen <aj@junglist.gen.nz>
+#
+
+collectd_plugin "load"
+

--- a/recipes/qmail_queue.rb
+++ b/recipes/qmail_queue.rb
@@ -1,0 +1,5 @@
+# use collectd filecount plugin to track queue length
+collectd_plugin "filecount" do
+  template "qmail_filecount.conf.erb"
+  cookbook "collectd_plugins"
+end


### PR DESCRIPTION
Completely based on work found in https://github.com/heavywater/echelon
- carbon.rb
- chef.rb
- graphite.rb
- librato.rb
- load.rb
- qmail_queue.rb
