### PR TITLE
Parameterized attributes for df, interface, and syslog plugin, and added a recipe for the load plugin.

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,23 @@ A number of recipes for standard plugins are available:
 
 It is recommended to always enable the first two (rrdtool and syslog), but the others are entirely optional. For convenience, the `collectd_plugins` default recipe will include all of these.
 
+# ATTRIBUTES #
+
+Several of the plugins use host attributes to control behavior.
+
+* df plugin 
+** `node['collectd_plugins']['df']['selected_fstypes']` - array of filesystem types to monitor or ignore.  If `'ignore_selected'` is true (default), this is a list of ignored types, and if it's false, it's a whitelist.  The default value is `["proc", "sysfs", "fusectl", "debugfs", "securityfs", "devtmpfs", "devpts", "tmpfs"]`.
+** `node['collectd_plugins']['df']['ignore_selected']` - boolean value; if true, use the `'selected_fstypes'` attribute as a blacklist; if false, treat `'selected_fstypes'` as a whitelist.  The default is true.
+** `node['collectd_plugins']['df']['report_reserved']` - boolean value; controls if we measure reserved space on the filesystem.  Defaults to false.
+** `node['collectd_plugins']['df']['report_inodes']` - boolean value; controls if we measure inode counts on the filesystem.  Defaults to false.
+
+* syslog plugin
+** `node['collectd_plugins']['syslog']['log_level']` - string; syslog priority used.  Allowable values are: emerg, alert, crit, err, warning, notice, info, debug.  Default is 'info'.
+
+* interface plugin
+** `node['collectd_plugins']['interface']['selected_interfaces']` - array of network interfaces to monitor or ignore.  If `'ignore_selected'` is true (default), this is a list of ignored types, and if it's false, it's a whitelist.  The default value is `[ "lo" ]`.
+** `node['collectd_plugins']['interface']['ignore_selected']` - boolean value; if true, use the `'selected_interfaces'` attribute as a blacklist; if false, treat `'selected_fstypes'` as a whitelist.  The default is true.
+
 ## Redis ##
 
 A plugin to monitor [Redis](http://redis.io/) is included as `collectd_plugins::redis`. This recipe requires that you be using our [redis cookbook](https://github.com/AtariTech/cookbooks/tree/master/redis)

--- a/README.md
+++ b/README.md
@@ -25,18 +25,18 @@ It is recommended to always enable the first two (rrdtool and syslog), but the o
 
 Several of the plugins use host attributes to control behavior.
 
-* df plugin 
-** `node['collectd_plugins']['df']['selected_fstypes']` - array of filesystem types to monitor or ignore.  If `'ignore_selected'` is true (default), this is a list of ignored types, and if it's false, it's a whitelist.  The default value is `["proc", "sysfs", "fusectl", "debugfs", "securityfs", "devtmpfs", "devpts", "tmpfs"]`.
-** `node['collectd_plugins']['df']['ignore_selected']` - boolean value; if true, use the `'selected_fstypes'` attribute as a blacklist; if false, treat `'selected_fstypes'` as a whitelist.  The default is true.
-** `node['collectd_plugins']['df']['report_reserved']` - boolean value; controls if we measure reserved space on the filesystem.  Defaults to false.
-** `node['collectd_plugins']['df']['report_inodes']` - boolean value; controls if we measure inode counts on the filesystem.  Defaults to false.
+## df plugin ##
+* `node['collectd_plugins']['df']['selected_fstypes']` - array of filesystem types to monitor or ignore.  If `'ignore_selected'` is true (default), this is a list of ignored types, and if it's false, it's a whitelist.  The default value is `["proc", "sysfs", "fusectl", "debugfs", "securityfs", "devtmpfs", "devpts", "tmpfs"]`.
+* `node['collectd_plugins']['df']['ignore_selected']` - boolean value; if true, use the `'selected_fstypes'` attribute as a blacklist; if false, treat `'selected_fstypes'` as a whitelist.  The default is true.
+* `node['collectd_plugins']['df']['report_reserved']` - boolean value; controls if we measure reserved space on the filesystem.  Defaults to false.
+* `node['collectd_plugins']['df']['report_inodes']` - boolean value; controls if we measure inode counts on the filesystem.  Defaults to false.
 
-* syslog plugin
-** `node['collectd_plugins']['syslog']['log_level']` - string; syslog priority used.  Allowable values are: emerg, alert, crit, err, warning, notice, info, debug.  Default is 'info'.
+## syslog plugin ##
+* `node['collectd_plugins']['syslog']['log_level']` - string; syslog priority used.  Allowable values are: emerg, alert, crit, err, warning, notice, info, debug.  Default is 'info'.
 
-* interface plugin
-** `node['collectd_plugins']['interface']['selected_interfaces']` - array of network interfaces to monitor or ignore.  If `'ignore_selected'` is true (default), this is a list of ignored types, and if it's false, it's a whitelist.  The default value is `[ "lo" ]`.
-** `node['collectd_plugins']['interface']['ignore_selected']` - boolean value; if true, use the `'selected_interfaces'` attribute as a blacklist; if false, treat `'selected_fstypes'` as a whitelist.  The default is true.
+## interface plugin ##
+* `node['collectd_plugins']['interface']['selected_interfaces']` - array of network interfaces to monitor or ignore.  If `'ignore_selected'` is true (default), this is a list of ignored types, and if it's false, it's a whitelist.  The default value is `[ "lo" ]`.
+* `node['collectd_plugins']['interface']['ignore_selected']` - boolean value; if true, use the `'selected_interfaces'` attribute as a blacklist; if false, treat `'selected_fstypes'` as a whitelist.  The default is true.
 
 ## Redis ##
 

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,0 +1,15 @@
+# list of filesystem types to monitor (or ignore) for the df plugin
+# if ignore_selected is true, it's a blacklist; if ignore_selected is false, it's a whitelist
+default['collectd_plugins']['df']['selected_fstypes'] = ["proc", "sysfs", "fusectl", "debugfs", "securityfs", "devtmpfs", "devpts", "tmpfs"]
+default['collectd_plugins']['df']['ignore_selected'] = true
+# report reserved space and inode counts
+default['collectd_plugins']['df']['report_reserved'] = false
+default['collectd_plugins']['df']['report_inodes'] = false
+
+# allowable: emerg, alert, crit, err, warning, notice, info, debug
+default['collectd_plugins']['syslog']['log_level'] = "info"
+
+# list of network interfaces to monitor (or ignore) for the interface plugin
+# if ignore_selected is true, it's a blacklist; if ignore_selected is false, it's a whitelist
+default['collectd_plugins']['interface']['selected_interfaces'] = ["lo"]
+default['collectd_plugins']['interface']['ignore_selected'] = true

--- a/metadata.rb
+++ b/metadata.rb
@@ -1,3 +1,4 @@
+name             "collectd_plugins"
 maintainer       "Noan Kantrowitz"
 maintainer_email "noah@coderanger.net"
 license          "Apache 2.0"

--- a/recipes/df.rb
+++ b/recipes/df.rb
@@ -20,7 +20,8 @@
 include_recipe "collectd"
 
 collectd_plugin "df" do
-  options(:report_reserved=>false,
-          "FSType"=>["proc", "sysfs", "fusectl", "debugfs", "securityfs", "devtmpfs", "devpts", "tmpfs"],
-          :ignore_selected=>true)
+  options(:report_reserved => node['collectd_plugins']['df']['report_reserved'],
+          :report_inodes => node['collectd_plugins']['df']['report_inodes'],
+          "FSType" => [node['collectd_plugins']['df']['selected_fstypes']].flatten,
+          :ignore_selected => node['collectd_plugins']['df']['ignore_selected'])
 end

--- a/recipes/interface.rb
+++ b/recipes/interface.rb
@@ -20,5 +20,6 @@
 include_recipe "collectd"
 
 collectd_plugin "interface" do
-  options :interface=>"lo", :ignore_selected=>true
+  options :interface => [node['collectd_plugins']['interface']['selected_interfaces']].flatten,
+    :ignore_selected => node['collectd_plugins']['interface']['ignore_selected']
 end

--- a/recipes/load.rb
+++ b/recipes/load.rb
@@ -1,8 +1,8 @@
 #
 # Cookbook Name:: collectd_plugins
-# Recipe:: syslog
+# Recipe:: swap
 #
-# Copyright 2010, Atari, Inc
+#
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -19,6 +19,4 @@
 
 include_recipe "collectd"
 
-collectd_plugin "syslog" do
-  options :log_level => node['collectd_plugins']['syslog']['log_level']
-end
+collectd_plugin "load"


### PR DESCRIPTION
I changed the default parameters for the df plugin to attributes, mostly so I could exclude NFS on some hosts as well.  While I was changing things to attributes, I also changed the interface and syslog plugin configurations, and added the load plugin as a recipe.  

Contributed freely -- please feel free to apply your own copyright statement to load.rb.
