### PR TITLE
Add name attribute to metadata

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -1,3 +1,4 @@
+name             "collectd_plugins"
 maintainer       "Noan Kantrowitz"
 maintainer_email "noah@coderanger.net"
 license          "Apache 2.0"


### PR DESCRIPTION
Without name `berks install` doesn't work:

```
The following error occurred while reading the cookbook
`collectd_plugins':
Ridley::Errors::MissingNameAttribute: The metadata at
'/var/folders/_6/dynlyds55yzgpx1f2j1f50g00000gn/T/d20150128-38106-1w7addv'
does not contain a 'name' attribute. While Chef does not strictly
enforce this requirement, Ridley cannot continue without a valid
metadata 'name' entry.
```
